### PR TITLE
Fix: Allow non-zero seconds in time picker

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
         <div class="flex flex-row gap-3 items-end mb-1">
           <div class="flex flex-col">
             <label for="picker-dt" class="text-sm text-slate-500">Pick date & time</label>
-            <input type="datetime-local" id="picker-dt" class="rounded-md border border-slate-300 px-2 py-1 text-base bg-slate-50 focus:outline-none focus:ring-2 focus:ring-blue-400" />
+            <input type="datetime-local" id="picker-dt" step="1" class="rounded-md border border-slate-300 px-2 py-1 text-base bg-slate-50 focus:outline-none focus:ring-2 focus:ring-blue-400" />
           </div>
           <div class="flex flex-col">
             <label for="picker-ms" class="text-sm text-slate-500">Milliseconds</label>


### PR DESCRIPTION
The `datetime-local` input for picking the date and time (`picker-dt`) defaults to a `step` attribute of 60 seconds. This means it effectively rounds or restricts time input to whole minutes, setting seconds to '00'. If a time with non-zero seconds was programmatically set on it (e.g., by manually typing into the main time field), it could lead to validation issues or the seconds being reset to '00' by the picker itself.

This change adds `step="1"` to the `picker-dt` input in `index.html`. This modification allows the `datetime-local` picker to accept and manage time values with second-level precision.

The JavaScript logic for synchronizing the `picker-dt`, `picker-ms`, and the main `time` input field (`toTimeField` and `fromTimeField` functions) already correctly handles parsing and formatting time strings with seconds and was found to be compatible with this change.

The main `time` input field's `pattern` attribute and the form's submit validation continue to enforce the `YYYY-MM-DD HH:MM:SS.mmm` format, ensuring data consistency.